### PR TITLE
Unstable (#18) ver. 1.16

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open('requirements.txt', 'r') as f:
 
 setup(
     name='skabenclient',
-    version='1.15.4',
+    version='1.16',
     description='SKABEN client ',
     license="MIT",
     long_description=long_description,

--- a/skabenclient/contexts.py
+++ b/skabenclient/contexts.py
@@ -48,10 +48,7 @@ class BaseContext:
         """ Read previous timestamp value from 'ts' file """
         with open(self.timestamp_fname, 'r') as fh:
             t = fh.read().rstrip()
-            if t:
-                return int(t)
-            else:
-                return 0
+            return int(t) or 0
 
     def rewrite_timestamp(self, new_ts):
         """ Write timestamp value to file 'ts' """
@@ -115,8 +112,9 @@ class EventContext(BaseContext):
         # receive update from server
         command = event.cmd.lower()
 
+        # update from server received, save to local config
         if command == 'update':
-            return self.send_task_response(event)
+            return self.save_config_and_report(event)
 
         # request config from server
         elif command == 'cup':
@@ -134,30 +132,29 @@ class EventContext(BaseContext):
 
         # send data to server directly without local db update
         elif command == 'info':
-            logging.debug('event is {} - sending data to server'.format(event))
+            logging.debug(f'sending {event.data} to server')
             return self.send_message(event.data)
 
         # input received, update local config, send to server
         elif command == 'input':
-            logging.debug('input event is {} - input: {}'.format(event, event.data))
+            logging.debug(f'new input: {event.data}')
             if event.data:
                 self.device.config.save(event.data)
                 return self.send_config(event.data)
             else:
-                logging.error('missing data from event: {}'.format(event))
+                logging.error(f'missing data from event: {event}')
 
         # reload device with current local config
         elif command in ('reload', 'reset'):
-            logging.debug('event is {} - reloading device'.format(event))
+            logging.debug('RESET event, reloading device')
             return self.device.state_reload()
 
-        # report bad event type
         else:
-            logging.error('bad event {}'.format(event))
+            logging.error(f'bad event {event}')
 
     def manage_mqtt(self, event):
-        """ Manage event from MQTT based on command
-            Translate commands into internal event queue
+        """Manage event from MQTT based on command
+           Translate commands into internal event queue
         """
 
         command = event.data.get('command')
@@ -239,7 +236,8 @@ class EventContext(BaseContext):
                         datahold=datahold)
         self.q_ext.put(packet.encode())
 
-    def send_task_response(self, event):
+
+    def save_config_and_report(self, event):
         """ ACK/NACK packet """
         task_id = event.data.get('task_id', '12345')
         response = 'ACK'

--- a/skabenclient/device.py
+++ b/skabenclient/device.py
@@ -11,6 +11,7 @@ class BaseDevice:
     """
 
     config_class = DeviceConfig
+    timers = {}
 
     def __init__(self, app_config, device_config):
         if not isinstance(app_config, SystemConfig):
@@ -28,17 +29,17 @@ class BaseDevice:
 
     def run(self):
         print('application is starting...')
-        self.logger.debug(f'device starting as: {self.system} \n {self.config}')
+        self.logger.debug(f'{self} starting with device config: \n {self.config}')
         reload_event = make_event('device', 'reload')
         self.q_int.put(reload_event)
 
     def stop(self):
         print('device is stopping...')
         self.logger.debug(f"stopping device {self}")
-        end_event = make_event("exit", '')
+        end_event = make_event("exit")
         self.q_int.put(end_event)
 
-    def state_update(self, data):
+    def state_update(self, data: dict):
         """ Update device configuration from user actions
 
             When new data from user actions received, check current config and if changed,
@@ -63,8 +64,23 @@ class BaseDevice:
         """ Re-read and apply device saved state """
         return self.config.load()
 
-    def send_message(self, data):
+    def send_message(self, data: dict):
         """ Send message to server """
         event = make_event('device', 'info', data)
         self.q_int.put(event)
         return event
+
+    def new_timer(self, start: int, count: int, name: str) -> str:
+        if int(count) > 0:
+            timer = start + count
+            self.timers.update({name: timer})
+            self.logger.debug(f"timer set at {start} with name {name} to {count}s")
+            return self.timers[name]
+
+    def check_timer(self, name: str, now: int) -> bool:
+        timer = self.timers.get(name)
+        if timer and timer <= now:
+            return timer
+
+    def __str__(self):
+        return f"Basic Device <{self.system}>"

--- a/skabenclient/main.py
+++ b/skabenclient/main.py
@@ -13,10 +13,13 @@ def start_app(app_config, device):
 
     app_config.update({'device': device})  # update config for easy access to device instance
     router = Router(app_config)  # initialize router for internal events
-    mqttc = MQTTClient(app_config)  # initialize MQTT client for talking with server
+    mqtt_client = None
+    standalone = app_config.get("standalone")
 
     try:
-        mqttc.start()
+        if not standalone:
+            mqtt_client = MQTTClient(app_config)  # initialize MQTT client for talking with server
+            mqtt_client.start()
         router.start()
         device.run()
         print(f'running application with config:\n {app_config}')
@@ -27,4 +30,5 @@ def start_app(app_config, device):
         raise
     finally:
         router.join(.5)
-        mqttc.join(.5)
+        if mqtt_client:
+            mqtt_client.join(.5)

--- a/skabenclient/tests/test_03_contexts.py
+++ b/skabenclient/tests/test_03_contexts.py
@@ -42,10 +42,11 @@ def test_event_extended_dict(event_setup, default_config):
 def test_event_context_update(event_setup, monkeypatch):
     """ Test update command """
     syscfg = event_setup()
-    event = make_event('device', 'update', {'value': 'newval',
-                                            'task_id': 123123})
     syscfg.get('device').config.set('value', 'oldval')
     syscfg.get('device').config.save()
+
+    event = make_event('device', 'update', {'value': 'newval',
+                                            'task_id': 123123})
 
     with mgr.EventContext(syscfg) as context:
         monkeypatch.setattr(context, 'confirm_update', lambda *args: {'task_id': args[0],


### PR DESCRIPTION
* initial commit

* moved some config parts from app to config

* versioning

* module importing

* versioning

* image and sound loaders added

* deploy script

* pygame version

* fixing soundloader

* tests

* basic loader tests

* docker for testing

* flake8 conf

* docker-compose for easy mount

* basic manager tests

* modified sound loader

* new version

* get rid of awk, thank you

* sound loader functionality

* 4.2 version

* pyaml versioning

* moving from sqlite to yaml, minor tests

* remove test database file

* separate configs for system and device, removing handlers class

* some tests for config

* some tests

* config tests

* device handler base class

* managers testing

* minor manager testing, skabenproto flaw found

* too lazy to deploy from docker

* more tests

* naming issues

* config tests

* FileLock moved to helpers

* minor changes

* minor changes in config handling

* versioning

* got to git gud at threads testing

* main app tests, teststructure changed

* fixing context tests

* components integrity and event managing tests

* managers renamed to contexts

* add mqtt event subclass

* minor fixes

* managers renamed to contexts

* some consistency

* remove ninja default config paths

* config path fixes

* versioning

* sound loader _snd forget about self

* fixing config, added custom root, updated tests

* fixes for sound loader

* basic logging configuration

* event_context should be passed to event router from now

* config estabilished as main data item, fixed tests

* fixed config initialisation

* fixed args passing

* gitlab ci

* formatting

* naming

* readme

* minor fixes

* fixed docker config

* fixed tests

* deploy fixed a bit, minor changes in contexts

* dev_type renamed to topic

* minor typo fixes in untested mqtt_client

* fixed pub/sub topics

* mqtt client fixed. need to test

* simplified contexts section, changed internal events syntax

* mqtt context simplified

* another mqtt fix

* mqtt is broken. need to be tested

* mqtt client now supports auto reconnect

* start merging contexts to one, mqtt context refactored

* fixed timestamp file path

* annual commit

* file structure, tests

* client id

* deployment tinkering

* raising exc when ip not provided

* keyboard interrupt

* minor fixes

* bad CUP in EventContext fixed

* bad dir structure still haunts us

* fixed tests with more complex payloads

* no deploy in compose - should be separated later

* tests

* SUP fixed, now it's only for sending current conf

* testing gitlab ci

* fixed

* fixed

* fix

* gitlab

* gitlab

* gitlab

* gitlab

* gitlab

* gitlab test

* gitlab

* flake fix

* trying to add deploy

* suddenly linting

* Update .gitlab-ci.yml

* Update .gitlab-ci.yml

* Update .gitlab-ci.yml

* Update README.md

* device send cup on start

* added different levels for external logging

* github actions not so good

* versioning

* fixed info messages send bug

* send info message bug fix

* Unstable

* vscode

* request device config on mqtt client connect

* linting

* fixed router naming

* updated tests

* minor improvements

* removed todo

* fixed main

* 15.5

* recursive config update, destructive update support

Co-authored-by: Dmitry Bis <foxtrot@rinet.ru>
Co-authored-by: zerthmonk <zerthmonk@yantra.sensenet>
Co-authored-by: Dmitry Bis <zerthmonk@users.noreply.github.com>